### PR TITLE
Add libwebp-base as dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,13 @@ requirements:
     - giflib  # [not win]
 
 test:
+  source_files:
+    - examples/test.webp
+    
   commands:
     - test -f $PREFIX/bin/cwebp  # [not win]
     - test -f $PREFIX/bin/dwebp  # [not win]
+    - dwebp examples/test.webp  # [not win]
     - if not exist %LIBRARY_LIB%\\libwebp.lib exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\libwebpdemux.lib exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\libwebpdecoder.lib exit 1  # [win]
@@ -44,6 +48,7 @@ test:
     - if not exist %LIBRARY_INC%\\webp\\decode.h exit 1  # [win]
     - if not exist %LIBRARY_INC%\\webp\\encode.h exit 1  # [win]
     - if not exist %LIBRARY_INC%\\webp\\types.h exit 1  # [win]
+    - dwebp examples\\test.webp  # [win]
 
 outputs:  # [not win]
   - name: libwebp  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
 
 build:
   number: 2
-  run_exports:
-    # https://abi-laboratory.pro/?view=timeline&l=libwebp
-    - {{ pin_subpackage('libwebp', max_pin='x.x') }}
+  run_exports:  # [win]
+    # https://abi-laboratory.pro/?view=timeline&l=libwebp  # [win]
+    - {{ pin_subpackage('libwebp', max_pin='x.x') }}  # [win]
 
 requirements:
   build:
@@ -56,13 +56,17 @@ outputs:  # [not win]
       - bin/  # [not win]
     requirements:  # [not win]
       run:  # [not win]
-        - libwebp-base  # [not win]
+        - {{ pin_subpackage('libwebp-base', exact=True) }}  # [not win]
         - jpeg  # [not win]
         - libpng  # [not win]
         - libtiff  # [not win]
         - giflib  # [not win]
 
   - name: libwebp-base  # [not win]
+    build:  # [not win]
+      run_exports:  # [not win]
+        # https://abi-laboratory.pro/?view=timeline&l=libwebp  # [not win]
+        - {{ pin_subpackage('libwebp-base', max_pin='x.x') }}  # [not win]
     files:  # [not win]
       - include/  # [not win]
       - share/  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 98a052268cc4d5ece27f76572a7f50293f439c17a98e67c4ea0c7ed6f50ef043
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_subpackage('libwebp', max_pin='x.x') }}
@@ -49,9 +49,9 @@ outputs:  # [not win]
   - name: libwebp  # [not win]
     files:  # [not win]
       - bin/  # [not win]
-      - {{ pin_subpackage('libwebp-base', exact=True) }}  # [not win]
     requirements:  # [not win]
       run:  # [not win]
+        - libwebp-base  # [not win]
         - jpeg  # [not win]
         - libpng  # [not win]
         - libtiff  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,10 @@ test:
 
 outputs:  # [not win]
   - name: libwebp  # [not win]
+    build:  # [not win]
+      run_exports:  # [not win]
+        # https://abi-laboratory.pro/?view=timeline&l=libwebp  # [not win]
+        - {{ pin_subpackage('libwebp-base', max_pin='x.x') }}  # [not win]
     files:  # [not win]
       - bin/  # [not win]
     requirements:  # [not win]


### PR DESCRIPTION
Adding libwebp-base is required because the package have been split into libwebp and libwebp-base.

cc @nicoddemus @tigarmo