### PR TITLE
BUG: Revert to autotools for OSX ABI

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -4,18 +4,5 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-jpeg:
-- '9'
-libpng:
-- '1.6'
-libtiff:
-- '4'
-pin_run_as_build:
-  jpeg:
-    max_pin: x
-  libpng:
-    max_pin: x.x
-  libtiff:
-    max_pin: x
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@ Development: https://chromium.googlesource.com/webm/libwebp
 
 Documentation: https://developers.google.com/speed/webp/docs/using
 
-WebP is a method of lossy and lossless compression that can be used on a large variety of photographic,
-translucent and graphical images found on the web. The degree of lossy compression is adjustable so a
-user can choose the trade-off between file size and image quality.
-libwebp-base provides the headers and shared libraries. For cwebp and dwep,
-binaries install libwebp.
+WebP is a method of lossy and lossless compression that can be used on a large variety of photographic, translucent and graphical images found on the web. The degree of lossy compression is adjustable so a user can choose the trade-off between file size and image quality. libwebp-base provides the headers and shared libraries. For cwebp and dwep, binaries install libwebp.
 
 
 Current build status

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,7 @@ cp $BUILD_PREFIX/share/gnuconfig/config.* .
     --enable-libwebpdecoder \
     --enable-libwebpdemux \
     --enable-libwebpmux \
-    --prefix=${SRC_DIR}/prefix \
+    --prefix=${PREFIX} \
     --with-gifincludedir=${PREFIX}/include \
     --with-giflibdir=${PREFIX}/lib \
     --with-jpegincludedir=${PREFIX}/include \
@@ -30,5 +30,7 @@ fi
 
 make install
 
-cp -R prefix/bin $PREFIX/
-cp -R prefix/share $PREFIX/
+# Remove all artifacts that are shipped with libwebp-base
+rm -f $PREFIX/include
+rm -f $PREFIX/lib
+rm -f $PREFIX/share

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,24 +4,31 @@ set -ex
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* .
 
-mkdir build
-cd build
+# The libwebp build script doesn't pick all the other libraries up on its own
+# (even though it should by using PREFIX), so pass all the necessary parameters
+# for finding other imaging libraries to the configure script.
+./configure \
+    --disable-dependency-tracking \
+    --disable-gl \
+    --disable-static \
+    --enable-libwebpdecoder \
+    --enable-libwebpdemux \
+    --enable-libwebpmux \
+    --prefix=${SRC_DIR}/prefix \
+    --with-gifincludedir=${PREFIX}/include \
+    --with-giflibdir=${PREFIX}/lib \
+    --with-jpegincludedir=${PREFIX}/include \
+    --with-jpeglibdir=${PREFIX}/lib \
+    --with-tiffincludedir=${PREFIX}/include \
+    --with-tifflibdir=${PREFIX}/lib \
 
-cmake .. ${CMAKE_ARGS} \
-    -DBUILD_SHARED_LIBS:BOOL=ON \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DWEBP_BUILD_CWEBP:BOOL=ON \
-    -DWEBP_BUILD_DWEBP:BOOL=ON \
-    -DWEBP_BUILD_EXTRAS:BOOL=OFF \
-    -DWEBP_BUILD_GIF2WEBP:BOOL=ON \
-    -DWEBP_BUILD_IMG2WEBP:BOOL=ON \
-    -DWEBP_BUILD_LIBWEBPMUX:BOOL=ON \
-    -DWEBP_BUILD_VWEBP:BOOL=ON \
-    -DWEBP_BUILD_WEBP_JS:BOOL=OFF \
-    -DWEBP_BUILD_WEBPINFO:BOOL=ON \
-    -DWEBP_BUILD_WEBPMUX:BOOL=ON \
-    -DWEBP_LINK_STATIC:BOOL=OFF \
+make
 
-cmake --build .
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
+make check
+fi
 
-cmake --install .
+make install
+
+cp -R prefix/bin $PREFIX/
+cp -R prefix/share $PREFIX/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,6 @@ fi
 make install
 
 # Remove all artifacts that are shipped with libwebp-base
-rm -f $PREFIX/include
-rm -f $PREFIX/lib
-rm -f $PREFIX/share
+rm -rf $PREFIX/include
+rm -rf $PREFIX/lib
+rm -rf $PREFIX/share

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,8 +29,3 @@ make check
 fi
 
 make install
-
-# Remove all artifacts that are shipped with libwebp-base
-rm -rf $PREFIX/include
-rm -rf $PREFIX/lib
-rm -rf $PREFIX/share

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f5d7ab2390b06b8a934a4fc35784291b3885b557780d099bd32f09241f9d83f9
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}
@@ -17,7 +17,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - cmake >=3.7          # [unix]
     - gnuconfig            # [unix]
     - make                 # [unix]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ about:
   license: BSD-3-Clause
   license_file: COPYING
   summary: WebP image library
-  description: |
+  description: >
     WebP is a method of lossy and lossless compression that can be used on a large variety of photographic,
     translucent and graphical images found on the web. The degree of lossy compression is adjustable so a
     user can choose the trade-off between file size and image quality.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes https://github.com/conda-forge/libwebp-base-feedstock/issues/11